### PR TITLE
Add HomePage widget test

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,24 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
 
 import 'package:too_taps/main.dart';
+import 'package:too_taps/Views/home_page.dart';
+import 'package:too_taps/controllers/theme_controller.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  setUp(() {
+    // Provide required controllers for the app.
+    Get.put(ThemeController());
+  });
+
+  tearDown(() {
+    Get.reset();
+  });
+
+  testWidgets('MyApp shows HomePage on startup', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.byType(HomePage), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- replace default Flutter counter test
- add a widget test verifying that `MyApp` shows `HomePage`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873acc615a48320a8850d098988303c