### PR TITLE
Add missing Android Context import

### DIFF
--- a/android/app/src/main/kotlin/com/example/too_taps/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/too_taps/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.too_taps
 
 import android.content.Intent
+import android.content.Context
 import android.os.Bundle
 import android.view.TextureView
 import io.flutter.embedding.android.FlutterActivity


### PR DESCRIPTION
## Summary
- add `android.content.Context` to `MainActivity.kt`

## Testing
- `gradle assembleDebug` *(fails: `/workspace/too_taps/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_687559eddf1c8320aa8e01957b7ea44d