### PR TITLE
Add distance counter widget with GPS

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <application
         android:label="too_taps"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,9 +41,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>Location is used to set your starting city for distance calculations.</string>
+<key>CADisableMinimumFrameDurationOnPhone</key>
+<true/>
+<key>UIApplicationSupportsIndirectInputEvents</key>
+<true/>
 </dict>
 </plist>

--- a/lib/Views/scrolling.dart
+++ b/lib/Views/scrolling.dart
@@ -9,6 +9,7 @@ import '../controllers/theme_controller.dart';
 import '../widgets/Navigazione/navigazione.dart'; // Importa Navigation
 import '../widgets/title_widget.dart'; // Importa TitleWidget
 import '../controllers/user_controller.dart';
+import '../widgets/distance_counter_widget.dart';
 
 class ScrollingPage extends StatefulWidget {
   final String userID;
@@ -126,20 +127,24 @@ class ScrollingPageState extends State<ScrollingPage> {
                     backgroundColor: Colors.transparent,
                     elevation: 0,
                     centerTitle: true, // Centro il titolo
-                    title: const Text(
-                      'Scrolling', // Scritta "Scrolling"
-                      style: TextStyle(
-                        fontSize: 20,
-                        color: Colors.white,
-                        fontFamily: 'KeplerStd',
-                        fontStyle: FontStyle.italic,
-                        fontWeight: FontWeight.normal,
-                      ),
+                  title: const Text(
+                    'Scrolling', // Scritta "Scrolling"
+                    style: TextStyle(
+                      fontSize: 20,
+                      color: Colors.white,
+                      fontFamily: 'KeplerStd',
+                      fontStyle: FontStyle.italic,
+                      fontWeight: FontWeight.normal,
                     ),
                   ),
-                  Expanded(
-                    child: Align(
-                      alignment: Alignment.bottomRight, // Fissa il contenuto in basso a destra
+                ),
+                const Padding(
+                  padding: EdgeInsets.all(16.0),
+                  child: DistanceCounterWidget(),
+                ),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.bottomRight, // Fissa il contenuto in basso a destra
                       child: Padding(
                         padding: const EdgeInsets.all(16.0), // Aggiunge un po' di padding se necessario
                         child: Obx(() {

--- a/lib/Widgets/distance_counter_widget.dart
+++ b/lib/Widgets/distance_counter_widget.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/Contatori/scroll_counter.dart';
+import '../services/location_service.dart';
+
+class DistanceCounterWidget extends StatefulWidget {
+  const DistanceCounterWidget({super.key});
+
+  @override
+  State<DistanceCounterWidget> createState() => _DistanceCounterWidgetState();
+}
+
+class _DistanceCounterWidgetState extends State<DistanceCounterWidget> {
+  final LocationService _locationService = LocationService();
+  String _city = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _initLocation();
+  }
+
+  Future<void> _initLocation() async {
+    final position = await _locationService.getCurrentPosition();
+    if (position != null) {
+      final city = await _locationService.getCityFromPosition(position);
+      if (mounted) {
+        setState(() {
+          _city = city;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scrollCounter = Get.find<ScrollCounter>();
+    return Obx(() {
+      final distanceKm = scrollCounter.scrolls.value.toDouble();
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            _city.isEmpty ? 'Unknown location' : 'City: $_city',
+            style: const TextStyle(color: Colors.white, fontSize: 16),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Distance from Earth: ${distanceKm.toStringAsFixed(0)} km',
+            style: const TextStyle(color: Colors.white, fontSize: 16),
+          ),
+        ],
+      );
+    });
+  }
+}

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -1,0 +1,35 @@
+import 'package:geolocator/geolocator.dart';
+import 'package:geocoding/geocoding.dart';
+
+class LocationService {
+  /// Returns the current device position if permissions are granted.
+  Future<Position?> getCurrentPosition() async {
+    bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      return null;
+    }
+
+    LocationPermission permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied ||
+          permission == LocationPermission.deniedForever) {
+        return null;
+      }
+    }
+
+    return Geolocator.getCurrentPosition();
+  }
+
+  /// Returns the city name from the provided [position].
+  Future<String> getCityFromPosition(Position position) async {
+    try {
+      final placemarks =
+          await placemarkFromCoordinates(position.latitude, position.longitude);
+      if (placemarks.isNotEmpty) {
+        return placemarks.first.locality ?? '';
+      }
+    } catch (_) {}
+    return '';
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   firebase_messaging: ^14.7.1
   firebase_storage: ^11.2.2
   cloud_firestore: ^4.15.4
+  geolocator: ^11.0.0
+  geocoding: ^2.2.0
 
 
 dev_dependencies:

--- a/test/widgets/distance_counter_widget_test.dart
+++ b/test/widgets/distance_counter_widget_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:too_taps/Widgets/distance_counter_widget.dart';
+import 'package:too_taps/controllers/Contatori/scroll_counter.dart';
+import 'package:too_taps/models/user_model.dart';
+
+void main() {
+  testWidgets('DistanceCounterWidget displays scroll distance', (WidgetTester tester) async {
+    final user = UserModel(
+      uid: '1',
+      displayName: 'Test',
+      email: 't@example.com',
+      photoUrl: '',
+      jobTitle: '',
+      postImage: '',
+    );
+    Get.put(ScrollCounter(user));
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: DistanceCounterWidget(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Distance from Earth'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add DistanceCounterWidget with current city and distance
- implement LocationService to fetch GPS position and city
- link DistanceCounterWidget into scrolling page
- add geolocator & geocoding dependencies
- request location permissions for Android and iOS
- include widget unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b8a7c66648320b66208da244077d2