### PR TITLE
Add PostAIService unit test with fake AI client

### DIFF
--- a/lib/services/post_ai_service.dart
+++ b/lib/services/post_ai_service.dart
@@ -1,22 +1,20 @@
 import 'dart:ui';
 import 'package:google_generative_ai/google_generative_ai.dart';
-=======
-import 'package:dart_openai/dart_openai.dart';
-
 import 'package:get/get.dart';
 
 class PostAIService {
-  PostAIService._();
+  PostAIService._({GenerativeModel? model}) : _model = model;
+
+  final GenerativeModel? _model;
 
   static final PostAIService instance = PostAIService._();
 
-  Future<String> generatePost(int scrolls, int touches) async {
+  Future<String> generatePost(int scrolls, int touches, {GenerativeModel? model}) async {
     final locale = Get.locale ?? const Locale('en', 'US');
     final languageCode = locale.languageCode;
 
     final apiKey = const String.fromEnvironment('GOOGLE_API_KEY', defaultValue: '');
-    final apiKey = const String.fromEnvironment('OPENAI_API_KEY', defaultValue: '');
-    if (apiKey.isEmpty) {
+    if (apiKey.isEmpty && model == null && _model == null) {
       // Simple fallback text if no API key is provided
       if (languageCode == 'it') {
         return 'Ho toccato solo $touches volte e scrollato $scrolls volte oggi! Continua così!';
@@ -26,25 +24,13 @@ class PostAIService {
 
     final languageName = _languageName(languageCode);
 
-    final model = GenerativeModel(model: 'gemini-pro', apiKey: apiKey);
+    final generativeModel = model ?? _model ?? GenerativeModel(model: 'gemini-pro', apiKey: apiKey);
     final prompt =
         'Create a short motivational post celebrating that the user performed only $touches touches and $scrolls scrolls. Reply in $languageName.';
-    final response = await model.generateContent([
+    final response = await generativeModel.generateContent([
       Content.text(prompt)
     ]);
     return response.text?.trim() ?? '';
-    OpenAI.apiKey = apiKey;
-
-    final languageName = _languageName(languageCode);
-
-    final completion = await OpenAI.instance.chat.create(
-      model: 'gpt-3.5-turbo',
-      messages: [
-        ChatMessage.system('You are an assistant that writes short social posts in $languageName.'),
-        ChatMessage.user('Create a short motivational post celebrating that the user performed only $touches touches and $scrolls scrolls. Reply in $languageName.'),
-      ],
-    );
-    return completion.choices.first.message.content.trim();
   }
 
   String _languageName(String code) {

--- a/test/services/post_ai_service_test.dart
+++ b/test/services/post_ai_service_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:too_taps/services/post_ai_service.dart';
+
+class FakeGenerateContentResponse implements GenerateContentResponse {
+  @override
+  final String? text;
+  FakeGenerateContentResponse(this.text);
+}
+
+class FakeGenerativeModel implements GenerativeModel {
+  final String responseText;
+  FakeGenerativeModel(this.responseText);
+
+  @override
+  Future<GenerateContentResponse> generateContent(List<Content> contents, {GenerationConfig? generationConfig}) async {
+    return FakeGenerateContentResponse(responseText);
+  }
+}
+
+void main() {
+  test('generatePost returns trimmed response text', () async {
+    final fakeModel = FakeGenerativeModel('  hello world  ');
+    final result = await PostAIService.instance.generatePost(2, 3, model: fakeModel);
+    expect(result, 'hello world');
+  });
+}


### PR DESCRIPTION
## Summary
- allow passing a `GenerativeModel` to `PostAIService.generatePost`
- clean up `post_ai_service.dart`
- add a fake Google Generative AI client for testing
- add new `post_ai_service_test.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880badb21fc8320b6df518a12b33e97