### PR TITLE
Fix duplicates in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,14 +32,8 @@ dependencies:
   firebase_storage: ^11.2.2
   cloud_firestore: ^4.15.4
   google_generative_ai: ^0.2.2
-  cloud_firestore: ^4.15.4  geolocator: ^10.1.0
-  geocoding: ^2.1.1
-
-
   geolocator: ^11.0.0
   geocoding: ^2.2.0
-
-
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- remove duplicate dependencies
- use consistent versions for `geolocator` and `geocoding`
- tidy blank lines in the dependency list

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880bada3a188320a2562c6371103cdb