### PR TITLE
Reintroduce PostAIService unit test

### DIFF
--- a/test/services/post_ai_service_test.dart
+++ b/test/services/post_ai_service_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:too_taps/services/post_ai_service.dart';
+
+class FakeGenerateContentResponse implements GenerateContentResponse {
+  @override
+  final String? text;
+
+  FakeGenerateContentResponse(this.text);
+}
+
+class FakeGenerativeModel implements GenerativeModel {
+  final String responseText;
+  FakeGenerativeModel(this.responseText);
+
+  @override
+  Future<GenerateContentResponse> generateContent(
+    List<Content> contents, {
+    GenerationConfig? generationConfig,
+  }) async {
+    return FakeGenerateContentResponse(responseText);
+  }
+}
+
+void main() {
+  test('generatePost returns trimmed response text', () async {
+    final fakeModel = FakeGenerativeModel('  hello world  ');
+    final result =
+        await PostAIService.instance.generatePost(2, 3, model: fakeModel);
+    expect(result, 'hello world');
+  });
+}


### PR DESCRIPTION
## Summary
- restore the `test/services/post_ai_service_test.dart` unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881032b6384832086200ab62b717787