### PR TITLE
Update google_generative_ai dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   firebase_messaging: ^14.7.1
   firebase_storage: ^11.2.2
   cloud_firestore: ^4.15.4
-  google_generative_ai: ^0.2.2
+  google_generative_ai: ^0.2.3
   geolocator: ^11.0.0
   geocoding: ^2.2.0
 


### PR DESCRIPTION
## Summary
- bump `google_generative_ai` to `^0.2.3`

## Testing
- `flutter pub get` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881033673848320b4552c52b8ddabbb