### PR TITLE
Fix spacing near geocoding dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,8 +35,6 @@ dependencies:
   geolocator: ^11.0.0
   geocoding: ^2.2.0
 
-
-
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- remove excess blank lines after the `geocoding` dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881033dcc288320a172498a93dfa4d4