### PR TITLE
Add GOOGLE_API_KEY setup info

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ samples, guidance on mobile development, and a full API reference.
 System-wide touch counting is supported only on Android. On iOS, touch
 detection is limited to interactions inside the app.
 
+## AI-generated posts
+
+The app can generate motivational posts using Google's generative AI
+services. To enable this feature you must provide a Google API key at
+compile time via the `GOOGLE_API_KEY` environment variable.
+
+Example command lines:
+
+```bash
+# Run on a connected device
+flutter run --dart-define=GOOGLE_API_KEY=YOUR_API_KEY
+
+# Build an APK
+flutter build apk --dart-define=GOOGLE_API_KEY=YOUR_API_KEY
+```
+
+If no key is supplied, the app falls back to local placeholder messages.
+
 ## License
 
 This project is licensed under the terms of the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- document how to pass the Google API key when running the app

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688103466a9c83209f0331a45501e3f5