### PR TITLE
Reintroduce PostAIService unit test

### DIFF
--- a/test/services/post_ai_service_test.dart
+++ b/test/services/post_ai_service_test.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:too_taps/services/post_ai_service.dart';
+
+void main() {
+  test('generatePost returns trimmed response text', () async {
+    final mockClient = MockClient((request) async {
+      final body = jsonEncode({
+        'candidates': [
+          {
+            'content': {
+              'parts': [
+                {'text': '  hello world  '}
+              ]
+            }
+          }
+        ]
+      });
+      return http.Response(body, 200);
+    });
+
+    final model = GenerativeModel(
+      model: 'gemini-pro',
+      apiKey: 'test-key',
+      httpClient: mockClient,
+    );
+
+    final result =
+        await PostAIService.instance.generatePost(2, 3, model: model);
+    expect(result, 'hello world');
+  });
+}


### PR DESCRIPTION
## Summary
- restore the `test/services/post_ai_service_test.dart` unit test
- use a `MockClient` to fake Gemini responses

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881032b6384832086200ab62b717787